### PR TITLE
Fix ld flag for OS X

### DIFF
--- a/lake.lua
+++ b/lake.lua
@@ -1490,7 +1490,11 @@ function set_flags(parms)
         LIB_PREFIX='lib'
         LIB_EXT='.a'
         SUBSYSTEM = '-Xlinker --subsystem -Xlinker  '  -- for mingw with Windows GUI
-        C_EXE_EXPORT = ' -Wl,-E'
+        if PLAT ~= 'Darwin' then
+            C_EXE_EXPORT = ' -Wl,-E'
+        else
+            C_EXE_EXPORT = ''
+        end
         C_STRIP = ' -Wl,-s'
         C_LIBSTATIC = ' -static'
         c.uses_dfile = 'slash'


### PR DESCRIPTION
ld on OS X (Darwin) doesn't support -E, and "-dynamic" appears to be default.  This patch allows the Lua sources to be built on OS X using the example from the README.md.
